### PR TITLE
Add explicit isort dependency

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,7 @@
 black==20.8b1
 flake8
 flake8-isort
+isort
 pydocstyle
 pylint
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ click==7.1.2              # via black
 flake8-isort==4.0.0       # via -r requirements-dev.in
 flake8==3.8.4             # via -r requirements-dev.in, flake8-isort
 iniconfig==1.0.0          # via pytest
-isort==4.3.21             # via flake8-isort, pylint
+isort==4.3.21             # via -r requirements-dev.in, flake8-isort, pylint
 lazy-object-proxy==1.4.2  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.3    # via black


### PR DESCRIPTION
We use Dependabot for updating dependencies in this repo, but it only
considers dependencies that are listed in the requirements-*.in files.
As flake8-isort is listed, but isort (which the former uses under the
hood) is not, it's possible for flake8-isort to be up-to-date, but
actually calling an out-of-date version of isort.

Adding isort to requirements-dev.in means Dependabot will keep this
dependency updated too.