### PR TITLE
Unpin pip and pip-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ sync:
 	pip-sync requirements.txt
 
 update:
-	pip-compile --allow-unsafe --quiet requirements.in --output-file requirements.txt
-	pip-compile --allow-unsafe --quiet requirements-dev.in --output-file requirements-dev.txt
+	pip-compile --allow-unsafe --upgrade --quiet requirements.in --output-file requirements.txt
+	pip-compile --allow-unsafe --upgrade --quiet requirements-dev.in --output-file requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: update sync
 
 sync:
-	pip-sync requirements.txt
+	pip-sync requirements-dev.txt requirements.txt
 
 update:
 	pip-compile --allow-unsafe --upgrade --quiet requirements.in --output-file requirements.txt

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,13 +2,7 @@ black==20.8b1
 flake8
 flake8-isort
 isort
-
-# pip-tools >= 5.4.0 changes the output format in a way that is currently incompatible
-# with Dependabot, so we'll pin it to a version that doesn't cause the issue. We also
-# need to pin pip itself, as pip-tools<5.4.0 is incompatible with pip>=20.3.
-pip<20.3
-pip-tools<5.4.0
-
+pip-tools
 pydocstyle
 pylint
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,37 +4,81 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
-appdirs==1.4.4            # via black
-astroid==2.4.2            # via pylint
-attrs==20.3.0             # via pytest
-black==20.8b1             # via -r requirements-dev.in
-click==7.1.2              # via black, pip-tools
-flake8-isort==4.0.0       # via -r requirements-dev.in
-flake8==3.8.4             # via -r requirements-dev.in, flake8-isort
-iniconfig==1.1.1          # via pytest
-isort==5.7.0              # via -r requirements-dev.in, flake8-isort, pylint
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via flake8, pylint
-mypy-extensions==0.4.3    # via black
-packaging==20.8           # via pytest
-pathspec==0.8.1           # via black
-pip-tools==5.5.0          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest
-py==1.10.0                # via pytest
-pycodestyle==2.6.0        # via flake8
-pydocstyle==5.1.1         # via -r requirements-dev.in
-pyflakes==2.2.0           # via flake8
-pylint==2.6.0             # via -r requirements-dev.in
-pyparsing==2.4.7          # via packaging
-pytest==6.2.1             # via -r requirements-dev.in
-regex==2020.11.13         # via black
-six==1.15.0               # via astroid
-snowballstemmer==2.0.0    # via pydocstyle
-testfixtures==6.17.1      # via flake8-isort
-toml==0.10.2              # via black, pylint, pytest
-typed-ast==1.4.2          # via black
-typing-extensions==3.7.4.3  # via black
-wrapt==1.12.1             # via astroid
+appdirs==1.4.4
+    # via black
+astroid==2.4.2
+    # via pylint
+attrs==20.3.0
+    # via pytest
+black==20.8b1
+    # via -r requirements-dev.in
+click==7.1.2
+    # via
+    #   black
+    #   pip-tools
+flake8-isort==4.0.0
+    # via -r requirements-dev.in
+flake8==3.8.4
+    # via
+    #   -r requirements-dev.in
+    #   flake8-isort
+iniconfig==1.1.1
+    # via pytest
+isort==5.7.0
+    # via
+    #   -r requirements-dev.in
+    #   flake8-isort
+    #   pylint
+lazy-object-proxy==1.4.3
+    # via astroid
+mccabe==0.6.1
+    # via
+    #   flake8
+    #   pylint
+mypy-extensions==0.4.3
+    # via black
+packaging==20.8
+    # via pytest
+pathspec==0.8.1
+    # via black
+pip-tools==5.5.0
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+py==1.10.0
+    # via pytest
+pycodestyle==2.6.0
+    # via flake8
+pydocstyle==5.1.1
+    # via -r requirements-dev.in
+pyflakes==2.2.0
+    # via flake8
+pylint==2.6.0
+    # via -r requirements-dev.in
+pyparsing==2.4.7
+    # via packaging
+pytest==6.2.1
+    # via -r requirements-dev.in
+regex==2020.11.13
+    # via black
+six==1.15.0
+    # via astroid
+snowballstemmer==2.0.0
+    # via pydocstyle
+testfixtures==6.17.1
+    # via flake8-isort
+toml==0.10.2
+    # via
+    #   black
+    #   pylint
+    #   pytest
+typed-ast==1.4.2
+    # via black
+typing-extensions==3.7.4.3
+    # via black
+wrapt==1.12.1
+    # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.3               # via pip-tools
+pip==20.3.3
+    # via pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,37 +4,37 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
-appdirs==1.4.3            # via black
-astroid==2.4.0            # via pylint
-attrs==19.2.0             # via pytest
+appdirs==1.4.4            # via black
+astroid==2.4.2            # via pylint
+attrs==20.3.0             # via pytest
 black==20.8b1             # via -r requirements-dev.in
 click==7.1.2              # via black, pip-tools
 flake8-isort==4.0.0       # via -r requirements-dev.in
 flake8==3.8.4             # via -r requirements-dev.in, flake8-isort
-iniconfig==1.0.0          # via pytest
+iniconfig==1.1.1          # via pytest
 isort==5.7.0              # via -r requirements-dev.in, flake8-isort, pylint
-lazy-object-proxy==1.4.2  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.3    # via black
-packaging==19.2           # via pytest
-pathspec==0.6.0           # via black
+packaging==20.8           # via pytest
+pathspec==0.8.1           # via black
 pip-tools==5.3.1          # via -r requirements-dev.in
-pluggy==0.13.0            # via pytest
-py==1.9.0                 # via pytest
+pluggy==0.13.1            # via pytest
+py==1.10.0                # via pytest
 pycodestyle==2.6.0        # via flake8
 pydocstyle==5.1.1         # via -r requirements-dev.in
 pyflakes==2.2.0           # via flake8
 pylint==2.6.0             # via -r requirements-dev.in
-pyparsing==2.4.3          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest==6.2.1             # via -r requirements-dev.in
-regex==2020.7.14          # via black
-six==1.12                 # via astroid, packaging, pip-tools
+regex==2020.11.13         # via black
+six==1.15.0               # via astroid, pip-tools
 snowballstemmer==2.0.0    # via pydocstyle
-testfixtures==6.10.0      # via flake8-isort
-toml==0.10.1              # via black, pylint, pytest
-typed-ast==1.4.0          # via black
+testfixtures==6.17.1      # via flake8-isort
+toml==0.10.2              # via black, pylint, pytest
+typed-ast==1.4.2          # via black
 typing-extensions==3.7.4.3  # via black
-wrapt==1.11.2             # via astroid
+wrapt==1.12.1             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.4               # via -r requirements-dev.in, pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.3    # via black
 packaging==20.8           # via pytest
 pathspec==0.8.1           # via black
-pip-tools==5.3.1          # via -r requirements-dev.in
+pip-tools==5.5.0          # via -r requirements-dev.in
 pluggy==0.13.1            # via pytest
 py==1.10.0                # via pytest
 pycodestyle==2.6.0        # via flake8
@@ -28,7 +28,7 @@ pylint==2.6.0             # via -r requirements-dev.in
 pyparsing==2.4.7          # via packaging
 pytest==6.2.1             # via -r requirements-dev.in
 regex==2020.11.13         # via black
-six==1.15.0               # via astroid, pip-tools
+six==1.15.0               # via astroid
 snowballstemmer==2.0.0    # via pydocstyle
 testfixtures==6.17.1      # via flake8-isort
 toml==0.10.2              # via black, pylint, pytest
@@ -37,4 +37,4 @@ typing-extensions==3.7.4.3  # via black
 wrapt==1.12.1             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.4               # via -r requirements-dev.in, pip-tools
+pip==20.3.3               # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,13 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt requirements.in
 #
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-idna==2.10                # via requests
-requests==2.25.1          # via -r requirements.in
-urllib3==1.26.2           # via requests
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+idna==2.10
+    # via requests
+requests==2.25.1
+    # via -r requirements.in
+urllib3==1.26.2
+    # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt requirements.in
 #
-certifi==2019.9.11        # via requests
-chardet==3.0.4            # via requests
-idna==2.8                 # via requests
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
+idna==2.10                # via requests
 requests==2.25.1          # via -r requirements.in
-urllib3==1.25.3           # via requests
+urllib3==1.26.2           # via requests


### PR DESCRIPTION
After Dependabot updated to use the latest version of pip-tools it's now generating the new-style output, meaning that its updates are generating whole-file diffs. This pull request migrates to the new style having checked that nothing else has changed so we can avoid future diff noise.