### PR TITLE
Store JAR versions in a Maven pom.xml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
   - package-ecosystem: pip
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,24 +7,17 @@ FROM groovy:jre8
 
 USER root
 
-ENV CODENARC_VERSION=2.1.0
-ENV SLF4J_VERSION=1.7.30
-ENV GMETRICS_VERSION=1.1
-
 RUN apt-get update \
     && apt-get install -y python3.8=3.8.* python3-pip=20.0.* --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+COPY pom.xml /opt/
 COPY ruleset.groovy /opt/resources/
 COPY run_codenarc.py /opt/
 
 WORKDIR /opt
-RUN python3.8 run_codenarc.py --resources /opt/resources \
-  --codenarc-version $CODENARC_VERSION \
-  --gmetrics-version $GMETRICS_VERSION \
-  --slf4j-version $SLF4J_VERSION
-
+RUN python3.8 run_codenarc.py --resources /opt/resources
 RUN groupadd -r jenkins && useradd --no-log-init -r -g jenkins jenkins
 USER jenkins
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ corresponding Docker image for that release.
 In order to ensure that the library is using a compatible version of the Docker image, a
 file named `VERSION` exists in the top-level directory of this project. To make a release,
 this file should be updated accordingly and the commit merged to the `master` branch.
+Please also update the groovylint version in `pom.xml`.
 
 Once on `master`, a new Docker image will be published by Ableton's CI service, which will
 also push a corresponding git tag to the origin and update the respective `major.minor`

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ableton</groupId>
+    <artifactId>groovylint</artifactId>
+    <version>0.12.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codenarc</groupId>
+            <artifactId>CodeNarc</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gmetrics</groupId>
+            <artifactId>GMetrics</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/run_codenarc.py
+++ b/run_codenarc.py
@@ -21,6 +21,7 @@ from xml.etree import ElementTree
 
 
 DEFAULT_REPORT_FILE = 'codenarc-report.xml'
+GROOVYLINT_HOME = os.path.dirname(os.path.realpath(__file__))
 
 
 class CodeNarcViolationsException(Exception):
@@ -257,7 +258,7 @@ def parse_args(args):
 
     arg_parser.add_argument(
         '--resources',
-        default=os.path.realpath(os.path.join(os.path.dirname(__file__), 'resources')),
+        default=os.path.join(GROOVYLINT_HOME, 'resources'),
         help='Path to Groovylint resources directory.',
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 Ableton AG, Berlin. All rights reserved.
+
+"""Test configuration for groovylint tests."""
+
+import pytest
+
+
+@pytest.fixture()
+def default_jar_versions():
+    """Return a dict for default JAR versions."""
+    return {
+        'CodeNarc': '1.0.0',
+        'GMetrics': '1.0.0',
+        'slf4j-api': '1.0.0',
+        'slf4j-simple': '1.0.0',
+    }

--- a/tests/test_run_codenarc.py
+++ b/tests/test_run_codenarc.py
@@ -58,7 +58,7 @@ def test_parse_xml_report_failed(report_file, num_violations):
 
 
 @patch('os.remove')
-def test_run_codenarc(remove_mock):
+def test_run_codenarc(remove_mock, default_jar_versions):
     """Test that run_codenarc exits without errors if CodeNarc ran successfully."""
     with patch('os.path.exists') as path_exists_mock:
         path_exists_mock.return_value = True
@@ -68,23 +68,14 @@ def test_run_codenarc(remove_mock):
             )
 
             output = run_codenarc(
-                args=parse_args(
-                    args=[
-                        '--codenarc-version',
-                        '1.0',
-                        '--gmetrics-version',
-                        '1.0',
-                        '--slf4j-version',
-                        '1.0',
-                    ]
-                ),
+                args=parse_args(args=[], default_jar_versions=default_jar_versions),
                 report_file=_report_file_path('success.xml'),
             )
 
     assert _report_file_contents('success.xml') == output
 
 
-def test_run_codenarc_compilation_failure():
+def test_run_codenarc_compilation_failure(default_jar_versions):
     """Test that run_codenarc raises an error if CodeNarc found compilation errors."""
     with patch('subprocess.run') as subprocess_mock:
         subprocess_mock.return_value = subprocess.CompletedProcess(
@@ -97,10 +88,12 @@ def test_run_codenarc_compilation_failure():
         )
 
         with pytest.raises(ValueError):
-            run_codenarc(args=parse_args(args=[]))
+            run_codenarc(
+                args=parse_args(args=[], default_jar_versions=default_jar_versions)
+            )
 
 
-def test_run_codenarc_failure_code():
+def test_run_codenarc_failure_code(default_jar_versions):
     """Test that run_codenarc raises an error if CodeNarc failed to run."""
     with patch('subprocess.run') as subprocess_mock:
         subprocess_mock.return_value = subprocess.CompletedProcess(
@@ -108,10 +101,12 @@ def test_run_codenarc_failure_code():
         )
 
         with pytest.raises(ValueError):
-            run_codenarc(args=parse_args(args=[]))
+            run_codenarc(
+                args=parse_args(args=[], default_jar_versions=default_jar_versions)
+            )
 
 
-def test_run_codenarc_no_report_file():
+def test_run_codenarc_no_report_file(default_jar_versions):
     """Test that run_codenarc raises an error if CodeNarc did not produce a report."""
     with patch('subprocess.run') as subprocess_mock:
         subprocess_mock.return_value = subprocess.CompletedProcess(
@@ -119,4 +114,7 @@ def test_run_codenarc_no_report_file():
         )
 
         with pytest.raises(ValueError):
-            run_codenarc(args=parse_args(args=[]), report_file='invalid')
+            run_codenarc(
+                args=parse_args(args=[], default_jar_versions=default_jar_versions),
+                report_file='invalid',
+            )


### PR DESCRIPTION
Yes, Maven. 😅 However, storing the JAR versions here offers two big advantages:

1. It allows the `pom.xml` to act as the canonical source for the default versions of all JAR files.
2. It enables us to use dependabot to bump our library versions.

Note that Maven itself is not required to use groovylint.