### PR TITLE
Don't include pipeline libraries in changelog

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@
  * license that can be found in the LICENSE file.
  */
 
-library 'ableton-utils@0.21'
-library 'python-utils@0.11'
+library(identifier: 'ableton-utils@0.21', changelog: false)
+library(identifier: 'python-utils@0.11', changelog: false)
 // Get groovylint library from current commit so it can test itself in this Jenkinsfile
 library "groovylint@${params.JENKINS_COMMIT}"
 


### PR DESCRIPTION
Aside from removing a bit of clutter from Jenkins build pages, this also
prevents commit authors of pipeline libraries from receiving build
failure notifications.
