### PR TITLE
Update hadolint to v2.9.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,15 +32,9 @@ devToolsProject.run(
   },
   test: { data ->
     parallel(failFast: false,
-      black: {
-        data.venv.run('black --check .')
-      },
-      flake8: {
-        data.venv.run('flake8 -v')
-      },
-      groovydoc: {
-        data['docs'] = groovydoc.generate()
-      },
+      black: { data.venv.run('black --check .') },
+      flake8: { data.venv.run('flake8 -v') },
+      groovydoc: { data['docs'] = groovydoc.generate() },
       'groovylint docker': {
         // Use the Docker image created in the Build stage above. This ensures that the
         // we are checking our own Groovy code with the same library and image which would
@@ -68,12 +62,8 @@ devToolsProject.run(
           sh 'hadolint /ws/Dockerfile'
         }
       },
-      pydocstyle: {
-        data.venv.run('pydocstyle -v')
-      },
-      pylint: {
-        data.venv.run('pylint --max-line-length=90 *.py')
-      },
+      pydocstyle: { data.venv.run('pydocstyle -v') },
+      pylint: { data.venv.run('pylint --max-line-length=90 *.py') },
       pytest: {
         withEnv([
           'GROOVY_HOME=test',
@@ -90,9 +80,7 @@ devToolsProject.run(
       },
     )
   },
-  publish: { data ->
-    jupiter.publishDocs("${data['docs']}/", 'Ableton/groovylint')
-  },
+  publish: { data -> jupiter.publishDocs("${data['docs']}/", 'Ableton/groovylint') },
   deployWhen: { return devToolsProject.shouldDeploy() },
   deploy: { data ->
     String versionNumber = readFile('VERSION').trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,8 @@ devToolsProject.run(
           ' -- -includes="./Jenkinsfile,**/*.groovy,**/*.gradle"'
       },
       hadolint: {
-        docker.image('hadolint/hadolint:v1.13.0-debian').inside("-v ${pwd()}:/ws") {
-          sh 'hadolint /ws/Dockerfile'
+        docker.image('hadolint/hadolint:v1.13.0-debian').inside {
+          sh 'hadolint Dockerfile'
         }
       },
       pydocstyle: { data.venv.run('pydocstyle -v') },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ devToolsProject.run(
           ' -- -includes="./Jenkinsfile,**/*.groovy,**/*.gradle"'
       },
       hadolint: {
-        docker.image('hadolint/hadolint:v1.13.0-debian').inside {
+        docker.image('hadolint/hadolint:v2.9.3-debian').inside {
           sh 'hadolint Dockerfile'
         }
       },


### PR DESCRIPTION
- Cleanup: condense one-line closures
- Cleanup: remove unnecessary volume mapping
- Update hadolint to v2.9.3
