### PR TITLE
Check SLF4J versions in Jenkinsfile tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,26 @@ devToolsProject.run(
           }
         }
       },
+      'SLF4J version check': {
+        Set slf4jVersions = []
+        readMavenPom(file: 'pom.xml').dependencies.findAll { dependency ->
+          return dependency.artifactId.startsWith('slf4j')
+        }.each { dependency ->
+          slf4jVersions.add(dependency.version)
+        }
+
+        switch (slf4jVersions.size()) {
+          case 0:
+            error 'Could not find SLF4J libraries in pom.xml file'
+            break
+          case 1:
+            echo 'All SLF4J versions match'
+            break
+          default:
+            error 'pom.xml file contains mismatched SLF4J library versions'
+            break
+        }
+      },
     )
   },
   publish: { data -> jupiter.publishDocs("${data['docs']}/", 'Ableton/groovylint') },


### PR DESCRIPTION
When dependabot submits a PR to update SLF4J, it isn't smart enough to
update all libraries at the same time. This can lead to groovylint using
mismatched library versions, which can lead to undefined behavior.
