### PR TITLE
Add a test to make sure groovylint fails properly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,20 @@ devToolsProject.run(
             groovylintImage: data['image'],
           )
         },
+        'groovylint failure': {
+          boolean failed = false
+          try {
+            groovylint.checkSingleFile(
+              groovylintImage: data['image'],
+              path: 'tests/resources/failure.badgroovy',
+            )
+          } catch (error) {
+            failed = true
+          }
+          if (!failed) {
+            error 'groovylint did not fail when analyzing code with violations'
+          }
+        },
         'groovylint native': {
           // Run groovylint using the system Python. This is not a recommended use-case
           // for Jenkins CI installations, but is often more useful for developers running

--- a/tests/resources/failure.badgroovy
+++ b/tests/resources/failure.badgroovy
@@ -1,0 +1,1 @@
+def foo = 'hello'


### PR DESCRIPTION
In the past, we had an error in groovylint where it didn't fail with a
non-zero exit code. This test is to make sure that regression doesn't
happen again.
