### PR TITLE
Force use of German Ubuntu mirror for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM groovy:4.0.24-jdk21-jammy
 
 USER root
 
+RUN sed --in-place -e 's/archive.ubuntu.com/de.archive.ubuntu.com/g' /etc/apt/sources.list
+
 # For add-apt-repository
 RUN apt-get update \
     && apt-get install -y software-properties-common=0.99.* --no-install-recommends \


### PR DESCRIPTION
Although a mirror *should* be selected automatically, it seems that this
isn't working properly and is causing the `docker build` operations to
fail with a slew of error messages resembling the following:

> Failed to fetch http://archive.ubuntu.com/ubuntu/<whatever>.deb 403
> Forbidden [IP: 185.125.190.83 80]

This might be caused a temporary network issue on Ubuntu's end (possibly
a DNS misconfiguration), but this workaround should be fine regardless.
